### PR TITLE
feat: remove _checkCompleteLoan

### DIFF
--- a/src/spro/Spro.sol
+++ b/src/spro/Spro.sol
@@ -541,17 +541,6 @@ contract Spro is SproVault, SproStorage, ISpro, Ownable2Step, ISproLoanMetadataP
         }
     }
 
-    /**
-     * @notice Checks for a complete loan with credit amount equal to available credit limit
-     * @param _creditAmount Credit amount of the proposal.
-     * @param _availableCreditLimit Available credit limit of the proposal.
-     */
-    function _checkCompleteLoan(uint256 _creditAmount, uint256 _availableCreditLimit) internal pure {
-        if (_creditAmount != _availableCreditLimit) {
-            revert OnlyCompleteLendingForNFTs(_creditAmount, _availableCreditLimit);
-        }
-    }
-
     /* -------------------------------------------------------------------------- */
     /*                                   PRIVATE                                  */
     /* -------------------------------------------------------------------------- */

--- a/test/helper/SproHandler.sol
+++ b/test/helper/SproHandler.sol
@@ -24,8 +24,4 @@ contract SproHandler is Spro {
     ) external {
         _withdrawCreditFromPool(credit, creditAmount, loanTerms.lender, lenderSpec.sourceOfFunds);
     }
-
-    function exposed_checkCompleteLoan(uint256 _creditAmount, uint256 _availableCreditLimit) external pure {
-        _checkCompleteLoan(_creditAmount, _availableCreditLimit);
-    }
 }

--- a/test/unit/SproSimpleLoan.t.sol
+++ b/test/unit/SproSimpleLoan.t.sol
@@ -83,11 +83,4 @@ contract SproSimpleLoanTest is Test {
         );
         sproHandler.exposed_checkLoanCreditAddress(loanCreditAddress, expectedCreditAddress);
     }
-
-    function testFuzz_shouldFail_partialLoan(uint256 a, uint256 l) external {
-        vm.assume(a != l);
-
-        vm.expectRevert(abi.encodeWithSelector(ISproErrors.OnlyCompleteLendingForNFTs.selector, a, l));
-        sproHandler.exposed_checkCompleteLoan(a, l);
-    }
 }


### PR DESCRIPTION
function _checkCompleteLoan was used only for ERC721 and ERC1155. So, it can be removed now

Closes RA2BL-134