### PR TITLE
feat: delete unnecessary check in _checkLoanCanBeRepaid

### DIFF
--- a/src/spro/Spro.sol
+++ b/src/spro/Spro.sol
@@ -488,10 +488,6 @@ contract Spro is SproVault, SproStorage, ISpro, Ownable2Step, ISproLoanMetadataP
      * @param loanExpiration Loan default timestamp.
      */
     function _checkLoanCanBeRepaid(LoanStatus status, uint40 loanExpiration) internal view {
-        // Check that loan exists and is not from a different loan contract
-        if (status == LoanStatus.NONE) {
-            revert NonExistingLoan();
-        }
         // Check that loan is running
         if (status != LoanStatus.RUNNING) {
             revert LoanNotRunning();

--- a/test/unit/SproSimpleLoan.t.sol
+++ b/test/unit/SproSimpleLoan.t.sol
@@ -51,17 +51,15 @@ contract SproSimpleLoanTest is Test {
         assertEq(amount, 0);
     }
 
-    function test_shouldFail_checkLoanCanBeRepaid_NonExistingLoan() external {
-        vm.expectRevert(ISproErrors.NonExistingLoan.selector);
-        sproHandler.exposed_checkLoanCanBeRepaid(ISproTypes.LoanStatus.NONE, 0);
-
-        vm.expectRevert(ISproErrors.LoanNotRunning.selector);
-        sproHandler.exposed_checkLoanCanBeRepaid(ISproTypes.LoanStatus.PAID_BACK, 0);
-    }
-
     function test_shouldFail_checkLoanCanBeRepaid_LoanNotRunning() external {
         vm.expectRevert(ISproErrors.LoanNotRunning.selector);
         sproHandler.exposed_checkLoanCanBeRepaid(ISproTypes.LoanStatus.PAID_BACK, 0);
+
+        vm.expectRevert(ISproErrors.LoanNotRunning.selector);
+        sproHandler.exposed_checkLoanCanBeRepaid(ISproTypes.LoanStatus.NONE, 0);
+
+        vm.expectRevert(ISproErrors.LoanNotRunning.selector);
+        sproHandler.exposed_checkLoanCanBeRepaid(ISproTypes.LoanStatus.EXPIRED, 0);
     }
 
     function test_shouldFail_checkLoanCanBeRepaid_LoanDefaulted() external {


### PR DESCRIPTION
this pr aims to reduce the number of checks. one check on the status instead of unnecessary two checks
the corresponding test was deleted

Closes RA2BL-132