### PR TITLE
fix: adding an equal to a comparison for the proposal duration

### DIFF
--- a/src/spro/Spro.sol
+++ b/src/spro/Spro.sol
@@ -551,7 +551,7 @@ contract Spro is SproVault, SproStorage, ISpro, Ownable2Step, ISproLoanMetadataP
         returns (address proposer_, address collateral_, uint256 collateralAmount_)
     {
         // Decode proposal data
-        if (proposal.startTimestamp > proposal.loanExpiration) {
+        if (proposal.startTimestamp >= proposal.loanExpiration) {
             revert InvalidDurationStartTime();
         }
 

--- a/test/integration/concrete/simple-loan/create-proposal/createProposal.t.sol
+++ b/test/integration/concrete/simple-loan/create-proposal/createProposal.t.sol
@@ -92,7 +92,7 @@ contract CreateProposal_SDSimpleLoan_Integration_Concrete_Test is SDBaseIntegrat
     {
         // Set bad timestamp value
         proposal.startTimestamp = uint40(block.timestamp);
-        proposal.loanExpiration = proposal.startTimestamp - 1;
+        proposal.loanExpiration = proposal.startTimestamp;
 
         // Mint initial state & approve collateral
         t20.mint(borrower, proposal.collateralAmount);


### PR DESCRIPTION
This pr aims to avoid the creation of a proposal with a start time equal to the end time
I added just an equal and adapted the corresponding test

Closes RA2BL-129