### PR TITLE
feat: incorporate pool adapter address in loan

### DIFF
--- a/src/interfaces/ISproTypes.sol
+++ b/src/interfaces/ISproTypes.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
+import { IPoolAdapter } from "src/interfaces/IPoolAdapter.sol";
+
 interface ISproTypes {
     /**
      * @notice Struct defining a simple loan terms.
@@ -67,6 +69,8 @@ interface ISproTypes {
      * @param status Loan status.
      * @param creditAddress Address of an asset used as a loan credit.
      * @param originalSourceOfFunds Address of a source of funds that was used to fund the loan.
+     * @param poolAdapter Address of a pool adapter used to withdraw and supply assets to the pool. address(0) if the
+     * originalSourceOfFound is the lender.
      * @param startTimestamp Unix timestamp (in seconds) of a start date.
      * @param loanExpiration Unix timestamp (in seconds) of a default date.
      * @param borrower Address of a borrower.
@@ -84,6 +88,7 @@ interface ISproTypes {
         LoanStatus status;
         address creditAddress;
         address originalSourceOfFunds;
+        IPoolAdapter poolAdapter;
         uint40 startTimestamp;
         uint40 loanExpiration;
         address borrower;

--- a/src/spro/Spro.sol
+++ b/src/spro/Spro.sol
@@ -241,11 +241,16 @@ contract Spro is SproVault, SproStorage, ISpro, Ownable2Step, ISproLoanMetadataP
         bytes calldata extra,
         bytes calldata permit2Data
     ) external returns (uint256 loanId_) {
+        address poolAdapter = _poolAdapterRegistry[lenderSpec.sourceOfFunds];
+        if (lenderSpec.sourceOfFunds != msg.sender && poolAdapter == address(0)) {
+            revert InvalidSourceOfFunds(lenderSpec.sourceOfFunds);
+        }
+
         // Accept proposal and get loan terms
         (bytes32 proposalHash, Terms memory loanTerms) = _acceptProposal(msg.sender, lenderSpec.creditAmount, proposal);
 
         // Create a new loan
-        loanId_ = _createLoan(loanTerms, lenderSpec);
+        loanId_ = _createLoan(loanTerms, lenderSpec, poolAdapter);
 
         emit LoanCreated(loanId_, proposalHash, loanTerms, lenderSpec, extra);
 
@@ -254,7 +259,7 @@ contract Spro is SproVault, SproStorage, ISpro, Ownable2Step, ISproLoanMetadataP
             _permit2Workflows(permit2Data, loanTerms.creditAmount.toUint160(), loanTerms.credit);
         } else {
             // Settle the loan - Transfer credit to borrower
-            _settleNewLoan(loanTerms, lenderSpec.sourceOfFunds);
+            _settleNewLoan(loanTerms, poolAdapter, lenderSpec.sourceOfFunds);
         }
     }
 
@@ -407,17 +412,8 @@ contract Spro is SproVault, SproStorage, ISpro, Ownable2Step, ISproLoanMetadataP
         if (destinationOfFunds == loanOwner) {
             _push(credit, creditAmount, loanOwner);
         } else {
-            IPoolAdapter poolAdapter = getPoolAdapter(destinationOfFunds);
-            // Check that pool has registered adapter
-            if (address(poolAdapter) == address(0)) {
-                // Note: Adapter can be unregistered during the loan lifetime, so the pool might not have an adapter.
-                // In that case, the loan owner will be able to claim the repaid credit.
-
-                revert InvalidSourceOfFunds(destinationOfFunds);
-            }
-
             // Supply the repaid credit to the original pool
-            _supplyToPool(credit, creditAmount, poolAdapter, destinationOfFunds, loanOwner);
+            _supplyToPool(credit, creditAmount, loan.poolAdapter, destinationOfFunds, loanOwner);
         }
 
         // Note: If the transfer fails, the Loan token will remain in repaid state and the Loan token owner
@@ -510,27 +506,6 @@ contract Spro is SproVault, SproStorage, ISpro, Ownable2Step, ISproLoanMetadataP
     function _checkLoanCreditAddress(address loanCreditAddress, address expectedCreditAddress) internal pure {
         if (loanCreditAddress != expectedCreditAddress) {
             revert DifferentCreditAddress(loanCreditAddress, expectedCreditAddress);
-        }
-    }
-
-    /**
-     * @notice Withdraw a credit asset from a pool to the Vault.
-     * @dev The function will revert if pool doesn't have registered pool adapter.
-     * @param credit Asset to be pulled from the pool.
-     * @param creditAmount Amount of an asset to be pulled.
-     * @param lender Address of a lender.
-     * @param sourceOfFunds Address of a source of funds.
-     */
-    function _withdrawCreditFromPool(address credit, uint256 creditAmount, address lender, address sourceOfFunds)
-        internal
-    {
-        IPoolAdapter poolAdapter = getPoolAdapter(sourceOfFunds);
-        if (address(poolAdapter) == address(0)) {
-            revert InvalidSourceOfFunds(sourceOfFunds);
-        }
-
-        if (creditAmount > 0) {
-            _withdrawFromPool(credit, creditAmount, poolAdapter, sourceOfFunds, lender);
         }
     }
 
@@ -715,9 +690,13 @@ contract Spro is SproVault, SproStorage, ISpro, Ownable2Step, ISproLoanMetadataP
      * @notice Mint Loan token and store loan data under loan id.
      * @param loanTerms Loan terms struct.
      * @param lenderSpec Lender specification struct.
+     * @param poolAdapter Address of a pool adapter.
      * @return loanId_ Id of the created Loan token.
      */
-    function _createLoan(Terms memory loanTerms, LenderSpec calldata lenderSpec) private returns (uint256 loanId_) {
+    function _createLoan(Terms memory loanTerms, LenderSpec calldata lenderSpec, address poolAdapter)
+        private
+        returns (uint256 loanId_)
+    {
         // Mint Loan token for lender
         loanId_ = loanToken.mint(loanTerms.lender);
 
@@ -726,6 +705,7 @@ contract Spro is SproVault, SproStorage, ISpro, Ownable2Step, ISproLoanMetadataP
         loan.status = LoanStatus.RUNNING;
         loan.creditAddress = loanTerms.credit;
         loan.originalSourceOfFunds = lenderSpec.sourceOfFunds;
+        loan.poolAdapter = IPoolAdapter(poolAdapter);
         loan.startTimestamp = loanTerms.startTimestamp;
         loan.loanExpiration = loanTerms.loanExpiration;
         loan.borrower = loanTerms.borrower;
@@ -741,13 +721,16 @@ contract Spro is SproVault, SproStorage, ISpro, Ownable2Step, ISproLoanMetadataP
      * @notice Transfers credit to borrower
      * @dev The function assumes a prior token approval to a contract address or signed permits.
      * @param loanTerms Loan terms struct.
+     * @param poolAdapter Address of a pool adapter.
      * @param sourceOfFunds Address of a source of funds.
      */
-    function _settleNewLoan(Terms memory loanTerms, address sourceOfFunds) private {
+    function _settleNewLoan(Terms memory loanTerms, address poolAdapter, address sourceOfFunds) private {
         // Lender is not the source of funds
-        if (sourceOfFunds != loanTerms.lender) {
+        if (sourceOfFunds != loanTerms.lender && loanTerms.creditAmount > 0) {
             // Withdraw credit asset to the lender first
-            _withdrawCreditFromPool(loanTerms.credit, loanTerms.creditAmount, loanTerms.lender, sourceOfFunds);
+            _withdrawFromPool(
+                loanTerms.credit, loanTerms.creditAmount, IPoolAdapter(poolAdapter), sourceOfFunds, loanTerms.lender
+            );
         }
 
         // Transfer credit to borrower

--- a/test/helper/SproHandler.sol
+++ b/test/helper/SproHandler.sol
@@ -15,13 +15,4 @@ contract SproHandler is Spro {
     function exposed_checkLoanCreditAddress(address loanCreditAddress, address expectedCreditAddress) external pure {
         _checkLoanCreditAddress(loanCreditAddress, expectedCreditAddress);
     }
-
-    function exposed_withdrawCreditFromPool(
-        address credit,
-        uint256 creditAmount,
-        Terms memory loanTerms,
-        LenderSpec calldata lenderSpec
-    ) external {
-        _withdrawCreditFromPool(credit, creditAmount, loanTerms.lender, lenderSpec.sourceOfFunds);
-    }
 }

--- a/test/integration/SDSimpleLoanIntegrationTest.t.sol
+++ b/test/integration/SDSimpleLoanIntegrationTest.t.sol
@@ -528,4 +528,18 @@ contract SDSimpleLoanIntegrationTest is SDBaseIntegrationTest {
 
         assertEq(deployment.config.loanRepaymentAmount(loanId), amount + loanInfo.fixedInterestAmount + accruedInterest);
     }
+
+    function test_RevertWhen_InvalidSourceOfFunds() external {
+        _createERC20Proposal();
+        address sourceOfFunds = makeAddr("sourceOfFunds");
+
+        vm.prank(lender);
+        vm.expectRevert(abi.encodeWithSelector(ISproErrors.InvalidSourceOfFunds.selector, sourceOfFunds));
+        deployment.config.createLoan({
+            proposal: proposal,
+            lenderSpec: ISproTypes.LenderSpec(sourceOfFunds, CREDIT_LIMIT, ""),
+            extra: "",
+            permit2Data: ""
+        });
+    }
 }

--- a/test/unit/SproSimpleLoan.t.sol
+++ b/test/unit/SproSimpleLoan.t.sol
@@ -29,22 +29,6 @@ contract SproSimpleLoanTest is Test {
         vm.mockCall(config, abi.encodeWithSignature("getPoolAdapter(address)"), abi.encode(poolAdapter));
     }
 
-    function testFuzz_shouldFail_withdrawCreditFromPool_InvalidSourceOfFunds(
-        address source,
-        uint256 amount,
-        bytes memory data
-    ) external {
-        address credit_;
-        Spro.Terms memory loanTerms;
-        Spro.LenderSpec memory lenderSpec =
-            ISproTypes.LenderSpec({ sourceOfFunds: source, creditAmount: amount, permitData: data });
-
-        vm.mockCall(config, abi.encodeWithSignature("getPoolAdapter(address)"), abi.encode(address(0)));
-
-        vm.expectRevert(abi.encodeWithSelector(ISproErrors.InvalidSourceOfFunds.selector, lenderSpec.sourceOfFunds));
-        sproHandler.exposed_withdrawCreditFromPool(credit_, amount, loanTerms, lenderSpec);
-    }
-
     function test_loanRepaymentAmount_shouldReturnZeroForNonExistingLoan() external view {
         uint256 amount = sproHandler.loanRepaymentAmount(0);
 


### PR DESCRIPTION
This pr aims to freeze the pool adapter address by storing it while creating a loan. This means the address change by the owner of the contract(with "registerPoolAdapter" function) doesn't affect loans already created

Closes RA2BL-155