### PR TITLE
ci(lintspec): pin lintspec version

### DIFF
--- a/.github/workflows/natspec.yml
+++ b/.github/workflows/natspec.yml
@@ -17,6 +17,7 @@ jobs:
         uses: beeb/lintspec@main
         with:
           fail-on-problem: "false" # we handle failure manually to be able to trigger the notification
+          version: "0.3.0"
       - name: Fail on findings
         if: ${{ steps.lintspec-action.outputs.total-diags > 0 }}
         run: exit 1

--- a/flake.lock
+++ b/flake.lock
@@ -59,15 +59,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1741684213,
-        "narHash": "sha256-iCfXWEOGzfQhBj10qQ8sdlRow7q0YfrHN8gRmeiiYP4=",
+        "lastModified": 1739524201,
+        "narHash": "sha256-ihmDBJIcM8sMvzYDGCc2aas34kLOEwXQuWlOvocChjk=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "44e47bd7f04ee4f89376c6de47d285515e7f2e6c",
+        "rev": "72db7ea069f055d5c7856aca091179a070201931",
         "type": "github"
       },
       "original": {
         "owner": "shazow",
+        "ref": "stable",
         "repo": "foundry.nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     foundry = {
-      url = "github:shazow/foundry.nix";
+      url = "github:shazow/foundry.nix/stable";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     solc = {


### PR DESCRIPTION
Because a new breaking version was released, the CI would fail to parse the config file.

When the new version is available on nixpkgs, this version and the config file will be updated.
