### PR TITLE
feat(_makeProposal): reverts when the start timestamp is in the past

### DIFF
--- a/src/interfaces/ISproErrors.sol
+++ b/src/interfaces/ISproErrors.sol
@@ -87,8 +87,11 @@ interface ISproErrors {
     /// @notice Thrown when the proposal does not exist.
     error ProposalDoesNotExists();
 
-    /// @notice Thrown when the proposal expiration is earlier or equal to the current timestamp.
-    error InvalidDurationStartTime();
+    /**
+     * @notice Thrown when the proposal start time is invalid.
+     * @dev Either the start time is in the past or the start time is after the expiration time.
+     */
+    error InvalidStartTime();
 
     /**
      * @notice Thrown when owner tries to set a fee that is higher than the maximum allowed.

--- a/src/spro/Spro.sol
+++ b/src/spro/Spro.sol
@@ -338,7 +338,7 @@ contract Spro is SproStorage, ISpro, Ownable2Step, ReentrancyGuard {
      */
     function _makeProposal(Proposal memory proposal) internal {
         if (proposal.startTimestamp >= proposal.loanExpiration || proposal.startTimestamp < block.timestamp) {
-            revert InvalidDurationStartTime();
+            revert InvalidStartTime();
         }
         if (proposal.availableCreditLimit == 0) {
             revert AvailableCreditLimitZero();

--- a/test/integration/SproIntegrationProposal.t.sol
+++ b/test/integration/SproIntegrationProposal.t.sol
@@ -46,7 +46,7 @@ contract SproIntegrationProposal is SDBaseIntegrationTest {
         spro.createProposal(proposal, "");
     }
 
-    function test_RevertWhen_InvalidDurationStartTime() external {
+    function test_RevertWhen_InvalidStartTime() external {
         // Set bad timestamp value
         proposal.startTimestamp = uint40(block.timestamp);
         proposal.loanExpiration = proposal.startTimestamp;
@@ -57,14 +57,14 @@ contract SproIntegrationProposal is SDBaseIntegrationTest {
         collateral.approve(address(spro), proposal.collateralAmount);
 
         vm.prank(borrower);
-        vm.expectRevert(abi.encodeWithSelector(ISproErrors.InvalidDurationStartTime.selector));
+        vm.expectRevert(abi.encodeWithSelector(ISproErrors.InvalidStartTime.selector));
         spro.createProposal(proposal, "");
 
         // Revert when startTimestamp is in the past
         proposal.startTimestamp = uint40(block.timestamp - 1);
         proposal.loanExpiration = proposal.startTimestamp + spro.MIN_LOAN_DURATION();
         vm.prank(borrower);
-        vm.expectRevert(abi.encodeWithSelector(ISproErrors.InvalidDurationStartTime.selector));
+        vm.expectRevert(abi.encodeWithSelector(ISproErrors.InvalidStartTime.selector));
         spro.createProposal(proposal, "");
     }
 


### PR DESCRIPTION
This PR adds a condition to the start timestamp of a proposal: if it is less than block.timestamp, the transaction will now revert.

Closes RA2BL-689.