### PR TITLE
fix: add package.json entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "snapshot:check": "FOUNDRY_PROFILE=ci forge build && FOUNDRY_PROFILE=ci forge snapshot --no-match-test \"(FFI|Fork|Fuzz)\" --no-match-contract Fork --check --offline",
     "test": "forge test"
   },
+  "main": "dist/index.js",
   "files": [
     "dist",
     "docs",


### PR DESCRIPTION
I've manually published the 1.0.0 abis with the fix but for next releases (if any), the package.json should include an entrypoint else we can't use it.